### PR TITLE
Fix evo2 minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ python bacbench/modeling/run_embed_dna.py \
     --max-seq-len 2048 \
     --dna-seq-overlap 32 \
     --agg-whole-genome \
+    --genome-pooling-method mean \
     --streaming
 ```
 

--- a/bacbench/modeling/embed_dna.py
+++ b/bacbench/modeling/embed_dna.py
@@ -6,8 +6,8 @@ import pandas as pd
 import torch
 
 from bacbench.modeling.embedder import SeqEmbedder
-from bacbench.modeling.utils.utils_evo import prepare_gene_seqs_for_evo
-from bacbench.modeling.utils.utils_glm2 import preprocess_whole_genome_for_glm2
+from bacbench.modeling.utils.scripts.utils_evo import prepare_gene_seqs_for_evo
+from bacbench.modeling.utils.scripts.utils_glm2 import preprocess_whole_genome_for_glm2
 
 
 def get_dna_seq(
@@ -185,8 +185,9 @@ def generate_dna_embeddings(
     # Process the DNA sequences in batches
     for i in range(0, len(dna_sequence), batch_size):
         batch_sequences = dna_sequence[i : i + batch_size]
-        with torch.no_grad():
-            dna_representations = embedder(batch_sequences, max_seq_len, pooling="mean", gene_mask=gene_mask)
+        batch_gene_mask = gene_mask[i : i + batch_size] if gene_mask is not None else None
+        with torch.inference_mode():
+            dna_representations = embedder(batch_sequences, max_seq_len, pooling="mean", gene_mask=batch_gene_mask)
 
         # Append the generated embeddings to the list
         dna_embeddings_arr += dna_representations
@@ -235,7 +236,7 @@ def embed_genome_dna_sequences(
         gene_mask = None
     # embed the dna sequence for each gene
     else:
-        if embedder.model_type == "evo":
+        if embedder.model_type in {"evo", "evo2"}:
             dna, gene_mask = prepare_gene_seqs_for_evo(
                 dna=dna,
                 start=start,
@@ -254,7 +255,7 @@ def embed_genome_dna_sequences(
                 max_seq_len=max_seq_len,
                 dna_seq_overlap=dna_seq_overlap,
             )
-            gene_mask = None  # only used for Evo model
+            gene_mask = None  # only used for Evo/Evo2 models
 
     # embed protein sequences
     dna_embeddings = generate_dna_embeddings(

--- a/bacbench/modeling/embed_dna.py
+++ b/bacbench/modeling/embed_dna.py
@@ -8,7 +8,11 @@ from tqdm.auto import tqdm
 
 from bacbench.modeling.embedder import SeqEmbedder
 from bacbench.modeling.utils.scripts.utils_evo import prepare_gene_seqs_for_evo
-from bacbench.modeling.utils.scripts.utils_glm2 import preprocess_whole_genome_for_glm2
+
+try:
+    from bacbench.modeling.utils.scripts.utils_glm2 import preprocess_whole_genome_for_glm2
+except ImportError:
+    preprocess_whole_genome_for_glm2 = None
 
 
 def get_dna_seq(

--- a/bacbench/modeling/embed_dna.py
+++ b/bacbench/modeling/embed_dna.py
@@ -296,6 +296,10 @@ def embed_genome_dna_sequences(
             return np.max(dna_embeddings, axis=0)
         raise ValueError(f"Unsupported genome pooling method: {genome_pooling_method}")
     else:
+        # Whole-genome mode has no gene indices; return chunk embeddings directly.
+        if gene_indices is None:
+            return dna_embeddings
+
         # if we don't pool, we return the list of embeddings and the gene indices
         gene_df = pd.DataFrame({"gene_idx": gene_indices, "dna_embedding": dna_embeddings})
         gene_df = gene_df.groupby("gene_idx")["dna_embedding"].apply(list)

--- a/bacbench/modeling/embed_dna.py
+++ b/bacbench/modeling/embed_dna.py
@@ -4,6 +4,7 @@ from typing import Literal
 import numpy as np
 import pandas as pd
 import torch
+from tqdm.auto import tqdm
 
 from bacbench.modeling.embedder import SeqEmbedder
 from bacbench.modeling.utils.scripts.utils_evo import prepare_gene_seqs_for_evo
@@ -166,6 +167,8 @@ def generate_dna_embeddings(
     batch_size: int = 128,
     max_seq_len: int = 2048,
     gene_mask: list[list[int]] | None = None,
+    show_progress: bool = False,
+    progress_desc: str | None = None,
 ) -> list[np.ndarray]:
     """Generate DNA embeddings using pretrained models.
 
@@ -183,6 +186,10 @@ def generate_dna_embeddings(
     dna_embeddings_arr = []
 
     # Process the DNA sequences in batches
+    pbar = None
+    if show_progress:
+        pbar = tqdm(total=len(dna_sequence), desc=progress_desc or "Embedding DNA sequences", unit="seq", leave=False)
+
     for i in range(0, len(dna_sequence), batch_size):
         batch_sequences = dna_sequence[i : i + batch_size]
         batch_gene_mask = gene_mask[i : i + batch_size] if gene_mask is not None else None
@@ -191,6 +198,11 @@ def generate_dna_embeddings(
 
         # Append the generated embeddings to the list
         dna_embeddings_arr += dna_representations
+        if pbar is not None:
+            pbar.update(len(batch_sequences))
+
+    if pbar is not None:
+        pbar.close()
 
     return dna_embeddings_arr
 
@@ -258,12 +270,16 @@ def embed_genome_dna_sequences(
             gene_mask = None  # only used for Evo/Evo2 models
 
     # embed protein sequences
+    show_progress = embedder.model_type in {"evo", "evo2"} and start is not None and end is not None
+
     dna_embeddings = generate_dna_embeddings(
         embedder=embedder,
         dna_sequence=dna,
         batch_size=batch_size,
         max_seq_len=max_seq_len,
         gene_mask=gene_mask,
+        show_progress=show_progress,
+        progress_desc="Embedding genes/seqs (Evo/Evo2)",
     )
 
     # if we pool all the embeddings at genome level, we don't care about the order and we just

--- a/bacbench/modeling/embedder.py
+++ b/bacbench/modeling/embedder.py
@@ -89,7 +89,7 @@ class SeqEmbedder(nn.Module):
         return inputs
 
     # ---------- public method -------------------------------------------
-    @torch.no_grad()
+    @torch.inference_mode()
     def forward(
         self,
         sequences: list[str],
@@ -115,7 +115,7 @@ class SeqEmbedder(nn.Module):
         seqs = self._preprocess_seqs(sequences)
 
         inputs = self._tokenize(seqs, max_seq_len=max_seq_len)
-        if self.model_type in ["evo", "glm2"] and gene_mask is not None:
+        if self.model_type in {"evo", "evo2", "glm2"} and gene_mask is not None:
             rep = self._forward_batch(inputs, pooling, gene_mask=gene_mask)
         else:
             rep = self._forward_batch(inputs, pooling)  # (B,D)
@@ -475,7 +475,7 @@ class Evo2Embedder(SeqEmbedder):
         # import evo2
         from evo2 import Evo2
 
-        self.model = Evo2("evo2_1b_base")
+        self.model = Evo2(model_name_or_path)
         # make sure the model is in eval mode and on the correct device
         self.model.model.eval()
 
@@ -485,16 +485,24 @@ class Evo2Embedder(SeqEmbedder):
         self.pad_id = self.tokenizer.pad_id
 
     def _tokenize(self, seqs: list[str], max_seq_len: int) -> dict[str, torch.Tensor]:
-        input_ids = [self.tokenizer.tokenize(s) for s in seqs]
-        max_seq_len = max(len(ids) for ids in input_ids)
-        # pad with self.pad_id and create attention mask
-        input_ids = torch.stack(
-            [torch.tensor(ids + [self.pad_id] * (max_seq_len - len(ids)), dtype=torch.long) for ids in input_ids]
-        ).to(self.device)
-        attention_mask = torch.stack(
-            [torch.tensor([1] * len(ids) + [0] * (max_seq_len - len(ids)), dtype=torch.long) for ids in input_ids]
-        ).to(self.device)
-        # move inputs to the same device as the model
+        if not seqs:
+            raise ValueError("Evo2Embedder received an empty batch.")
+
+        tokenized_ids = [self.tokenizer.tokenize(s)[:max_seq_len] for s in seqs]
+        batch_max_len = max(1, max(len(ids) for ids in tokenized_ids))
+
+        # pad with self.pad_id and create attention mask based on true (unpadded) token lengths
+        input_ids = torch.full((len(tokenized_ids), batch_max_len), self.pad_id, dtype=torch.long, device=self.device)
+        attention_mask = torch.zeros((len(tokenized_ids), batch_max_len), dtype=torch.long, device=self.device)
+
+        for row_idx, ids in enumerate(tokenized_ids):
+            if not ids:
+                continue
+            token_tensor = torch.tensor(ids, dtype=torch.long, device=self.device)
+            seq_len = token_tensor.size(0)
+            input_ids[row_idx, :seq_len] = token_tensor
+            attention_mask[row_idx, :seq_len] = 1
+
         return {"input_ids": input_ids, "attention_mask": attention_mask}
 
     def _forward_batch(
@@ -529,49 +537,52 @@ def load_seq_embedder(model_name_or_path: str, device: str = None):
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
 
+    model_name_or_path_lower = model_name_or_path.lower()
+
     # protein LMs
-    if "facebook/esm2" in model_name_or_path:
+    if "facebook/esm2" in model_name_or_path_lower:
         dtype = torch.float16 if faesm_installed else torch.float32
         return ESM2Embedder(model_name_or_path, dtype=dtype, device=device)
 
-    if "esmc" in model_name_or_path:
+    if "esmc" in model_name_or_path_lower:
         return ESMCEmbedder(model_name_or_path, dtype=torch.float16, device=device)
 
-    if "esmplusplus" in model_name_or_path.lower():
+    if "esmplusplus" in model_name_or_path_lower:
         return ESMPlusPlusEmbedder(model_name_or_path, dtype=torch.bfloat16, device=device)
 
-    if "prot_bert" in model_name_or_path:
+    if "prot_bert" in model_name_or_path_lower:
         return ProtBERTEmbedder(model_name_or_path, dtype=torch.float16, device=device)
 
-    if "progen2" in model_name_or_path:
+    if "progen2" in model_name_or_path_lower:
         return ProGen2Embedder(model_name_or_path, dtype=torch.float32, device=device)
 
     # DNA LMs
-    if "nucleotide-transformer" in model_name_or_path:
+    if "nucleotide-transformer" in model_name_or_path_lower:
         return NucleotideTransformerEmbedder(model_name_or_path, dtype=torch.float16, device=device)
 
-    if "DNABERT-2" in model_name_or_path:
+    if "dnabert-2" in model_name_or_path_lower:
         return DNABERT2Embedder(model_name_or_path, dtype=torch.float32, device=device)
 
-    if "Mistral-DNA" in model_name_or_path:
+    if "mistral-dna" in model_name_or_path_lower:
         return MistralDNAEmbedder(model_name_or_path, dtype=torch.float32, device=device)
 
-    if "prokbert" in model_name_or_path:
+    if "prokbert" in model_name_or_path_lower:
         return ProkBERTEmbedder(model_name_or_path, dtype=torch.float32, device=device)
 
     # mixed modality LMs
-    if "gLM2" in model_name_or_path:
+    if "glm2" in model_name_or_path_lower:
         return gLM2Embedder(model_name_or_path, dtype=torch.bfloat16, device=device)
 
-    if "evo2" in model_name_or_path:
+    if "evo2" in model_name_or_path_lower:
         print(
             "Loading Evo2 embedder, this requires Evo2 dependencies.\n"
-            "For more information, please check the Evo2 repository: https://github.com/ArcInstitute/evo2"
-            "Using evo2_1b_base model and extracting embeddings from the last layer before the output head (blocks.24.mlp.l3)."
+            "For more information, please check the Evo2 repository: https://github.com/ArcInstitute/evo2.\n"
+            f"Using Evo2 model identifier: {model_name_or_path}.\n"
+            "Default embedding layer is blocks.24.mlp.l3 unless overridden in Evo2Embedder._load."
         )
         return Evo2Embedder(model_name_or_path, device=device)
 
-    if "evo" in model_name_or_path:
+    if "evo" in model_name_or_path_lower:
         return EvoEmbedder(model_name_or_path, device=device, dtype=torch.bfloat16)
 
     raise ValueError(

--- a/bacbench/modeling/run_embed_dna.py
+++ b/bacbench/modeling/run_embed_dna.py
@@ -126,6 +126,10 @@ def run(
     :param output_dir: output directory for saving the dataframe, only used for iterable datasets and if save_every_n_rows is set
     :return: A pandas dataframe with the DNA embeddings.
     """
+    # Whole-genome mode should default to a single genome-level vector.
+    if agg_whole_genome and genome_pooling_method is None:
+        genome_pooling_method = "mean"
+
     # load DNA LM
     embedder = load_seq_embedder(model_path)
 

--- a/bacbench/modeling/run_embed_prot_seqs.py
+++ b/bacbench/modeling/run_embed_prot_seqs.py
@@ -68,6 +68,7 @@ def run(
     device: str = None,
     output_col: str = "embeddings",
     genome_pooling_method: Literal["mean", "max"] = None,
+    agg_whole_genome: bool = False,
     max_n_proteins: int = 9000,  # for Bacformer
     max_n_contigs: int = 1000,  # for Bacformer
     start_idx: int | None = None,  # for slicing the dataset
@@ -84,6 +85,7 @@ def run(
     :param device: device to use for embedding pLMs, if None, will use cuda if available
     :param output_col: name of the output column for the embeddings
     :param genome_pooling_method: pooling method for the genome level embedding, one of ["mean", "max"]
+    :param agg_whole_genome: if True and genome_pooling_method is None, defaults pooling to "mean"
     :param max_n_proteins: maximum number of proteins to use for each genome, only used for Bacformer
     :param max_n_contigs: maximum number of contigs to use for each genome, only used for Bacformer
     :param start_idx: start index for slicing the dataset, if None, will use the whole dataset
@@ -96,6 +98,10 @@ def run(
     # set device
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    # Whole-genome mode should default to a single genome-level vector.
+    if agg_whole_genome and genome_pooling_method is None:
+        genome_pooling_method = "mean"
 
     # check if the model is Bacformer and adjust accordingly
     bacformer_model = None
@@ -208,6 +214,7 @@ class ArgumentParser(Tap):
     device: str = None
     output_col: str = "embeddings"
     genome_pooling_method: Literal["mean", "max"] = None
+    agg_whole_genome: bool = False
     max_n_proteins: int = 9000  # for Bacformer
     max_n_contigs: int = 1000  # for Bacformer
     start_idx: int | None = None  # for slicing the dataset
@@ -261,6 +268,7 @@ if __name__ == "__main__":
         device=args.device,
         output_col=args.output_col,
         genome_pooling_method=args.genome_pooling_method,
+        agg_whole_genome=args.agg_whole_genome,
         max_n_proteins=args.max_n_proteins,
         max_n_contigs=args.max_n_contigs,
         start_idx=args.start_idx,

--- a/bacbench/tasks/antibiotic_resistance/README.md
+++ b/bacbench/tasks/antibiotic_resistance/README.md
@@ -46,6 +46,7 @@ python bacbench/modeling/run_embed_dna.py \
     --max-seq-len 2048 \
     --dna-seq-overlap 32 \
     --agg-whole-genome \
+    --genome-pooling-method mean \
     --streaming
 ```
 

--- a/bacbench/tasks/essential_genes/run_train_cls.py
+++ b/bacbench/tasks/essential_genes/run_train_cls.py
@@ -235,7 +235,7 @@ def main(
     # read input file
     df = pd.read_parquet(input_df_dile_path)
     # explode the embeddings column as after embedding it is a list of lists
-    df = prepare_essential_genes_df(df, embeddings_col=embeddings_col)
+    # df = prepare_essential_genes_df(df, embeddings_col=embeddings_col)
     # process the DF
     genome2idx = {g: i for i, g in enumerate(df["genome_name"].unique())}
     df["genome_idx"] = df["genome_name"].map(genome2idx)
@@ -361,15 +361,15 @@ class ArgumentParser(Tap):
         super().__init__(underscores_to_dashes=True)
 
     # file paths for loading data
-    input_df_file_path: str
-    output_dir: str
-    lr: float
+    input_df_file_path: str = "/Users/maciejwiatrak/Downloads/baclm_causal_essential_genes_embeddings.parquet"
+    output_dir: str = "/tmp/"
+    lr: float = 0.001
     dropout: float = 0.2
     max_epochs: int = 100
     batch_size: int = 256
     num_workers: int = 4
     test: bool = True
-    embeddings_col: str = "embeddings"
+    embeddings_col: str = "embedding"
     model_name: str = None
 
 

--- a/bacbench/tasks/essential_genes/run_train_cls.py
+++ b/bacbench/tasks/essential_genes/run_train_cls.py
@@ -235,7 +235,7 @@ def main(
     # read input file
     df = pd.read_parquet(input_df_dile_path)
     # explode the embeddings column as after embedding it is a list of lists
-    # df = prepare_essential_genes_df(df, embeddings_col=embeddings_col)
+    df = prepare_essential_genes_df(df, embeddings_col=embeddings_col)
     # process the DF
     genome2idx = {g: i for i, g in enumerate(df["genome_name"].unique())}
     df["genome_idx"] = df["genome_name"].map(genome2idx)

--- a/bacbench/tasks/essential_genes/run_train_cls.py
+++ b/bacbench/tasks/essential_genes/run_train_cls.py
@@ -361,15 +361,15 @@ class ArgumentParser(Tap):
         super().__init__(underscores_to_dashes=True)
 
     # file paths for loading data
-    input_df_file_path: str = "/Users/maciejwiatrak/Downloads/baclm_causal_essential_genes_embeddings.parquet"
-    output_dir: str = "/tmp/"
-    lr: float = 0.001
+    input_df_file_path: str
+    output_dir: str
+    lr: float
     dropout: float = 0.2
     max_epochs: int = 100
     batch_size: int = 256
     num_workers: int = 4
     test: bool = True
-    embeddings_col: str = "embedding"
+    embeddings_col: str = "embeddings"
     model_name: str = None
 
 

--- a/bacbench/tasks/phenotypic_traits/README.md
+++ b/bacbench/tasks/phenotypic_traits/README.md
@@ -43,6 +43,7 @@ python bacbench/modeling/run_embed_dna.py \
     --max-seq-len 2048 \
     --dna-seq-overlap 32 \
     --agg-whole-genome \
+    --genome-pooling-method mean \
     --streaming
 ```
 

--- a/bacbench/tasks/strain_clustering/README.md
+++ b/bacbench/tasks/strain_clustering/README.md
@@ -46,6 +46,7 @@ python bacbench/modeling/run_embed_dna.py \
     --max-seq-len 2048 \
     --dna-seq-overlap 32 \
     --agg-whole-genome \
+    --genome-pooling-method mean \
     --streaming
 ```
 


### PR DESCRIPTION
- Minor fixes for Evo2
- Add progress bar to Evo models (which take a long of time) at chunk rather then genome-level
- use torch.inference() model instead of torch.no_grad()
- fix the bug where the embeddings list is empty due to missing `--genome-pooling-method` when `--agg-whole-genome` is set to True