### PR TITLE
feat: add BacLM embedder implementation

### DIFF
--- a/bacbench/modeling/embedder.py
+++ b/bacbench/modeling/embedder.py
@@ -384,6 +384,41 @@ class gLM2Embedder(SeqEmbedder):
         return seq_representations
 
 
+class BacLMEmbedder(SeqEmbedder):
+    """Embedder for BacLM models from HuggingFace."""
+
+    def _load(self, model_name_or_path: str):
+        self.model = AutoModel.from_pretrained(model_name_or_path, trust_remote_code=True)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, trust_remote_code=True)
+        self.model_type = "baclm"
+
+    def _tokenize(self, seqs: list[str], max_seq_len: int) -> dict[str, torch.Tensor]:
+        inputs = self.tokenizer.batch_encode_plus(
+            seqs, return_tensors="pt", padding="longest", truncation=True, max_length=max_seq_len
+        )
+        # move inputs to the same device as the model
+        inputs = {k: v.to(self.device) for k, v in inputs.items()}
+        return inputs
+
+    def _forward_batch(
+        self,
+        inputs,
+        pooling: Literal["cls", "mean"] = "mean",
+    ) -> torch.Tensor:
+        last_hidden_state = self.model(
+            inputs["input_ids"],
+            attention_mask=inputs["attention_mask"],
+            token_type_ids=inputs["token_type_ids"],
+        ).last_hidden_state
+
+        if pooling == "cls":
+            return last_hidden_state[:, 0]  # (B,D)
+        seq_representations = torch.einsum(
+            "ijk,ij->ik", last_hidden_state, inputs["attention_mask"].type_as(last_hidden_state)
+        ) / inputs["attention_mask"].sum(1).unsqueeze(1)
+        return seq_representations
+
+
 class EvoEmbedder(SeqEmbedder):
     """Embedder for Evo models from HuggingFace."""
 
@@ -572,6 +607,9 @@ def load_seq_embedder(model_name_or_path: str, device: str = None):
     # mixed modality LMs
     if "glm2" in model_name_or_path_lower:
         return gLM2Embedder(model_name_or_path, dtype=torch.bfloat16, device=device)
+
+    if "baclm" in model_name_or_path_lower:
+        return BacLMEmbedder(model_name_or_path, dtype=torch.float32, device=device)
 
     if "evo2" in model_name_or_path_lower:
         print(

--- a/bacbench/modeling/run_embed_dna.py
+++ b/bacbench/modeling/run_embed_dna.py
@@ -135,6 +135,9 @@ def run(
 
     # embed DNA sequences across splits
     dfs = []
+    # if dataset is a dict of splits, keep it as is, otherwise make it a dict with a single split named "full"
+    if not isinstance(dataset, dict):
+        dataset = {"full": dataset}
     for split_name, split_ds in dataset.items():
         # slice the split
         split_ds = _slice_split(split_ds, start_idx, end_idx)

--- a/bacbench/modeling/run_embed_prot_seqs.py
+++ b/bacbench/modeling/run_embed_prot_seqs.py
@@ -127,7 +127,7 @@ def run(
     dfs = []
 
     # if dataset is a dict of splits, keep it as is, otherwise make it a dict with a single split named "full"
-    if not isinstance(Dataset, dict):
+    if not isinstance(dataset, dict):
         dataset = {"full": dataset}
     for split_name, split_ds in dataset.items():  # split_ds is a `Dataset`
         # slice the split

--- a/bacbench/tasks/antibiotic_resistance/train_and_predict_linear.py
+++ b/bacbench/tasks/antibiotic_resistance/train_and_predict_linear.py
@@ -1000,6 +1000,9 @@ if __name__ == "__main__":
     args = ArgParser().parse_args()
     os.makedirs(args.output_dir, exist_ok=True)
     df = pd.read_parquet(args.input_genomes_df_filepath)
+    # sort by genome_name to ensure consistent order
+    df = df.sort_values("genome_name").reset_index(drop=True)
+    # read labels and merge; assumes labels_df has "genome_name" + drug columns; inner join to keep only genomes with labels
     labels_df = pd.read_csv(args.labels_df_filepath)
     drug_cols = list(labels_df.columns[1:])
     df = pd.merge(df, labels_df, on="genome_name", how="inner")

--- a/bacbench/tasks/phenotypic_traits/train_and_predict_linear.py
+++ b/bacbench/tasks/phenotypic_traits/train_and_predict_linear.py
@@ -800,7 +800,7 @@ class ArgParser(Tap):
     train_size: float = 0.7
     val_size: float = 0.1
     test_size: float = 0.2
-    test_after_train: bool = True
+    test_after_train: bool = False
     limit_n_phenotypes: int | None = None  # limit number of phenotypes to process, for debugging
 
 

--- a/bacbench/tasks/phenotypic_traits/train_and_predict_linear.py
+++ b/bacbench/tasks/phenotypic_traits/train_and_predict_linear.py
@@ -808,7 +808,11 @@ if __name__ == "__main__":
     args = ArgParser().parse_args()
     os.makedirs(args.output_dir, exist_ok=True)
     df = pd.read_parquet(args.input_genomes_df_filepath)
+    # sort by genome_name to ensure consistent order
+    df = df.sort_values("genome_name").reset_index(drop=True)
+    # read labels
     labels_df = pd.read_csv(args.labels_df_filepath)
+    # merge on genome_name, inner join to keep only genomes with labels (should be all if data is correct)
     n_before_merge = len(df)
     df = df.merge(labels_df, on="genome_name", how="inner")
     n_after_merge = len(df)


### PR DESCRIPTION
- Add BacLM as an embedding model
- Ensure the ordering of genomes before the split for the phenotypic traits and AMR tasks
- Fix bug checking Dataset instance